### PR TITLE
Fix swagger doc generation issue

### DIFF
--- a/apps/server/app/v2/databases/[database]/tenants/[tenantId]/invite/route.ts
+++ b/apps/server/app/v2/databases/[database]/tenants/[tenantId]/invite/route.ts
@@ -172,7 +172,7 @@ export async function POST(
 /**
  * @swagger
  * /v2/databases/{database}/tenants/{tenantId}/invite:
- *   PUT:
+ *   put:
  *     tags:
  *       - tenants
  *     summary: Accepts a tenant invite


### PR DESCRIPTION
## Summary
- fix incorrect case in OpenAPI doc comment

## Testing
- `yarn build:spec` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6876b5247e548329af38da0941fa354e