### PR TITLE
chore(deps): add Dependabot config for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+
+registries:
+  github-packages-npm:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{ secrets.DEPENDABOT_PACKAGES_TOKEN }}
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    registries: ["github-packages-npm"]
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      non-major:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      non-major:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Net-new Dependabot config for this Yarn v4 turbo monorepo. The `npm` entry references a `registries:` block for the private GitHub Packages npm feed (`@niledatabase/server`), using org-level secret `DEPENDABOT_PACKAGES_TOKEN`. Both ecosystems get a `non-major` group, weekly schedule, and `chore(deps):` commit prefix.