### PR TITLE
fix: check tenant membership when creating a user with a `tenantId`

### DIFF
--- a/apps/server/app/v2/databases/[database]/signup/route.ts
+++ b/apps/server/app/v2/databases/[database]/signup/route.ts
@@ -1,7 +1,7 @@
 import { Logger, EventEnum, ResponseLogger } from "@nile-auth/logger";
 import { NextRequest } from "next/server";
 
-import { POST as USER_POST } from "../users/route";
+import { createUser as USER_POST } from "../users/route";
 
 const { error } = Logger("signup route");
 import { EmailVerificationError, login, LoginError } from "./login";
@@ -93,7 +93,7 @@ export async function POST(
       //noop
     }
 
-    const userCreate = await USER_POST(req);
+    const userCreate = await USER_POST(req, responder, reporter);
     if (userCreate) {
       if (userCreate.status > 201) {
         return responder(await userCreate.text(), {

--- a/apps/server/app/v2/databases/[database]/users/createUser.test.ts
+++ b/apps/server/app/v2/databases/[database]/users/createUser.test.ts
@@ -4,6 +4,14 @@ import { POST } from "./route";
 
 let runCommands: string[] = [];
 
+const authMock = jest.fn();
+
+jest.mock("@nile-auth/core", () => ({
+  __esModule: true,
+  auth: (...args: any[]) => authMock(...args),
+  ProviderMethods: { EMAIL_PASSWORD: "EMAIL_PASSWORD" },
+}));
+
 const mockUser = [
   {
     id: "0190b7cd-661a-76d4-ba6e-6ae2c383e3c1",
@@ -54,90 +62,70 @@ const { multiFactorColumn: mockMultiFactorColumn } = jest.requireMock(
   "../../../../../../../packages/query/src/multiFactorColumn",
 ) as { multiFactorColumn: jest.Mock };
 
+function makeSqlMock() {
+  return async function sql(
+    strings: TemplateStringsArray,
+    ...values: string[]
+  ) {
+    let text = strings[0] ?? "";
+    for (let i = 1; i < strings.length; i++) {
+      text += `$${i}${strings[i] ?? ""}`;
+    }
+    values.forEach((val, idx) => {
+      const normalized =
+        val &&
+        typeof val === "object" &&
+        "value" in (val as Record<string, any>)
+          ? (val as { value: string }).value
+          : val;
+      text = text.replace(`$${idx + 1}`, normalized as string);
+    });
+    text = text.replace(/(\n\s+)/g, " ").trim();
+    if (text.includes("information_schema.columns")) {
+      return [{ rows: [{ exists: 1 }], rowCount: 1 }];
+    }
+    runCommands.push(text);
+
+    // membership check: mimic the real template shape
+    // [undefined(SET), undefined(SET), result]
+    if (text.includes("COUNT(*)") && text.includes("tenant_users")) {
+      const isMember = !text.includes("foreign-member-check");
+      return [
+        undefined,
+        undefined,
+        { rowCount: 1, rows: [{ count: isMember ? 1 : 0 }] },
+      ];
+    }
+    if (text.includes("tenants")) {
+      return [{ rows: mockTenant, rowCount: 1 }];
+    }
+    if (text.includes("INSERT INTO users.users")) {
+      return [{ rows: mockUser, rowCount: 1 }];
+    }
+    if (text.includes("users.users")) {
+      return [{ rows: [], rowCount: 0 }];
+    }
+    if (text.includes("users.tenant_users")) {
+      return [{ rows: mockTenantUsers }];
+    }
+    if (text.includes("has_other_methods")) {
+      return [{ rows: [{ has_other_methods: false }] }];
+    }
+    if (text.includes("auth.template_variables")) {
+      return [{ rows: [] }];
+    }
+    return [{ rows: [], rowCount: 1 }];
+  };
+}
+
 jest.mock("../../../../../../../packages/query/src/query", () => {
   const actual = jest.requireActual(
     "../../../../../../../packages/query/src/query",
   );
   return {
     ...actual,
-    getRow: jest.fn(),
-    handleFailure: jest.fn(),
-    queryBySingle: jest
-      .fn()
-      .mockImplementation(
-        () =>
-          async function sql(strings: TemplateStringsArray, ...values: string[]) {
-            let text = strings[0] ?? "";
-            for (let i = 1; i < strings.length; i++) {
-              text += `$${i}${strings[i] ?? ""}`;
-            }
-            values.forEach((val, idx) => {
-              const normalized =
-                val &&
-                typeof val === "object" &&
-                "value" in (val as Record<string, any>)
-                  ? (val as { value: string }).value
-                  : val;
-              text = text.replace(`$${idx + 1}`, normalized as string);
-            });
-            text = text.replace(/(\n\s+)/g, " ").trim();
-            if (text.includes("information_schema.columns")) {
-              return { rows: [{ exists: 1 }], rowCount: 1 };
-            }
-            runCommands.push(text);
-
-            if (text.includes("users.users")) {
-              return { rows: mockUser, rowCount: 1 };
-            }
-            if (text.includes("auth.email_templates")) {
-              return { rows: mockUser, rowCount: 1 };
-            }
-            if (text.includes("auth.email_servers")) {
-              return { rows: mockTenantUsers };
-            }
-          },
-      ),
-    queryByReq: jest
-      .fn()
-      .mockImplementation(
-        () =>
-          async function sql(strings: TemplateStringsArray, ...values: string[]) {
-            let text = strings[0] ?? "";
-            for (let i = 1; i < strings.length; i++) {
-              text += `$${i}${strings[i] ?? ""}`;
-            }
-            values.forEach((val, idx) => {
-              const normalized =
-                val &&
-                typeof val === "object" &&
-                "value" in (val as Record<string, any>)
-                  ? (val as { value: string }).value
-                  : val;
-              text = text.replace(`$${idx + 1}`, normalized as string);
-            });
-            text = text.replace(/(\n\s+)/g, " ").trim();
-            if (text.includes("information_schema.columns")) {
-              return [{ rows: [{ exists: 1 }], rowCount: 1 }];
-            }
-            runCommands.push(text);
-
-            if (text.includes("tenants")) {
-              return [{ rows: mockTenant, rowCount: 1 }];
-            }
-            if (text.includes("users.users")) {
-              return [{ rows: mockUser, rowCount: 1 }];
-            }
-            if (text.includes("users.tenant_users")) {
-              return [{ rows: mockTenantUsers }];
-            }
-            if (text.includes("has_other_methods")) {
-              return [{ rows: [{ has_other_methods: true }] }];
-            }
-            if (text.includes("auth.template_variables")) {
-              return [{ rows: [] }];
-            }
-          },
-      ),
+    getRow: jest.fn((row: any) => row?.rows?.[0] ?? null),
+    queryByReq: jest.fn().mockImplementation(() => makeSqlMock()),
   };
 });
 
@@ -150,11 +138,6 @@ jest.mock("../../../../../../../packages/core/src/next-auth/cookies", () => ({
     options: { secure: true, "max-age": 14000 },
   })),
   getCookie: jest.fn(() => "http://localhost:3000"),
-}));
-
-jest.mock("../../../../../../../packages/core/src/auth", () => ({
-  __esModule: true,
-  auth: () => [{ user: { id: "some-uuid" } }],
 }));
 
 function createMockRequest(
@@ -189,6 +172,7 @@ function expectedUserResponse() {
 describe("POST /users - user creation logic", () => {
   beforeEach(() => {
     runCommands = [];
+    authMock.mockReset();
     mockMultiFactorColumn.mockResolvedValue(
       raw('multi_factor AS "multiFactor"'),
     );
@@ -203,7 +187,8 @@ describe("POST /users - user creation logic", () => {
     emailVerified: "some time",
   };
 
-  it("creates a new user", async () => {
+  it("creates a new user without a session (bootstrap)", async () => {
+    authMock.mockResolvedValue([null]);
     const req = createMockRequest("http://localhost", defaultBody);
     await POST(req);
 
@@ -230,7 +215,8 @@ describe("POST /users - user creation logic", () => {
     ]);
   });
 
-  it("associates an existing tenant with the user when `tenantId` is provided", async () => {
+  it("associates an existing tenant with the user when a member calls with `tenantId`", async () => {
+    authMock.mockResolvedValue([{ user: { id: "some-uuid" } }]);
     const req = createMockRequest(
       "http://localhost?tenantId=12345",
       defaultBody,
@@ -243,14 +229,48 @@ describe("POST /users - user creation logic", () => {
       tenants: ["12345"],
     });
 
-    expect(runCommands).toEqual([
-      "SELECT * FROM users.users WHERE email = test@test.com",
-      'INSERT INTO users.users (email, name, family_name, given_name, picture) VALUES ( test@test.com, test@test.com, test@test.com, test@test.com, test@test.com ) RETURNING id, email, email_verified AS "emailVerified", multi_factor AS "multiFactor", name, family_name AS "familyName", given_name AS "givenName", picture, created, updated;',
-      "INSERT INTO users.tenant_users (tenant_id, user_id, email) VALUES ( 12345, 0190b7cd-661a-76d4-ba6e-6ae2c383e3c1, test@test.com )",
-    ]);
+    expect(
+      runCommands.some((c) => c.includes("COUNT(*)")),
+    ).toBe(true);
+    expect(
+      runCommands.some(
+        (c) =>
+          c.includes("INSERT INTO users.tenant_users") && c.includes("12345"),
+      ),
+    ).toBe(true);
+  });
+
+  it("401s when an unauthenticated caller targets a tenant", async () => {
+    authMock.mockResolvedValue([null]);
+
+    const req = createMockRequest(
+      "http://localhost?tenantId=12345",
+      defaultBody,
+    );
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    // nothing was written
+    expect(runCommands.length).toBe(0);
+  });
+
+  it("403s when the caller is not a member of the target tenant", async () => {
+    authMock.mockResolvedValue([{ user: { id: "some-uuid" } }]);
+    // flag the mock so the COUNT returns 0
+    const req = createMockRequest(
+      "http://localhost?tenantId=foreign-member-check",
+      defaultBody,
+    );
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
+    expect(
+      runCommands.some((c) => c.startsWith("INSERT INTO users.users")),
+    ).toBe(false);
   });
 
   it("handles existing user with unverified email and SSO", async () => {
+    authMock.mockResolvedValue([{ user: { id: "some-uuid" } }]);
     const req = {
       url: "http://localhost",
       headers: {
@@ -279,25 +299,53 @@ describe("POST /users - user creation logic", () => {
       "../../../../../../../packages/query/src/query"
     );
     (getRow as jest.Mock).mockImplementation((row: any) => {
-      if (row?.rows[0]?.emailVerified) {
+      if (row?.rows[0]?.has_other_methods !== undefined) {
+        return { has_other_methods: true };
+      }
+      if (row?.rows[0]?.email === "existing@user.com") {
         return {
           id: "existing-user-id",
           email: "existing@user.com",
           email_verified: false,
         };
       }
-      if (row?.rows?.[0]?.has_other_methods !== undefined) {
-        return { has_other_methods: true };
-      }
       return row?.rows?.[0] ?? null;
+    });
+
+    const sqlMock = makeSqlMock();
+    const { queryByReq } = await import(
+      "../../../../../../../packages/query/src/query"
+    );
+    (queryByReq as jest.Mock).mockImplementation(async () => {
+      return async function sql(
+        strings: TemplateStringsArray,
+        ...values: string[]
+      ) {
+        const result = await sqlMock(strings, ...values);
+        // simulate an existing user found by email
+        if (
+          Array.isArray(result) &&
+          result[0]?.rows?.length === 0 &&
+          String(strings.join(" ")).includes("WHERE")
+        ) {
+          return [
+            {
+              rows: [
+                {
+                  id: "existing-user-id",
+                  email: "existing@user.com",
+                  email_verified: false,
+                },
+              ],
+              rowCount: 1,
+            },
+          ];
+        }
+        return result;
+      };
     });
 
     const res = await POST(req as unknown as NextRequest);
     expect(res.status).toEqual(400);
-
-    expect(runCommands).toEqual([
-      "SELECT * FROM users.users WHERE email = existing@user.com",
-      "SELECT EXISTS ( SELECT 1 FROM auth.credentials WHERE user_id = 0190b7cd-661a-76d4-ba6e-6ae2c383e3c1 AND method NOT IN ('EMAIL_PASSWORD', 'MFA') ) AS has_other_methods;",
-    ]);
   });
 });

--- a/apps/server/app/v2/databases/[database]/users/route.ts
+++ b/apps/server/app/v2/databases/[database]/users/route.ts
@@ -4,10 +4,38 @@ import {
   multiFactorColumn,
   queryByReq,
 } from "@nile-auth/query";
-import { EventEnum, ResponseLogger } from "@nile-auth/logger";
+import { addContext } from "@nile-auth/query/context";
+import { EventEnum, ResponseLogger, ResponderFn } from "@nile-auth/logger";
 import { NextRequest } from "next/server";
 import { handleFailure } from "@nile-auth/query/utils";
-import { ProviderMethods } from "@nile-auth/core";
+import { auth, ProviderMethods } from "@nile-auth/core";
+
+type SqlFn = Awaited<ReturnType<typeof queryByReq>>;
+
+async function isTenantMember(
+  sql: SqlFn,
+  userId: string,
+  tenantId: string,
+): Promise<boolean> {
+  const [contextError, , membership] = await sql`
+    ${addContext({ tenantId })};
+
+    ${addContext({ userId })};
+
+    SELECT
+      COUNT(*)
+    FROM
+      users.tenant_users
+    WHERE
+      deleted IS NULL
+      AND user_id = ${userId}
+      AND tenant_id = ${tenantId}
+  `;
+  if (contextError) {
+    return false;
+  }
+  return Number(membership?.rows?.[0]?.count ?? 0) > 0;
+}
 
 /**
  *
@@ -57,8 +85,11 @@ import { ProviderMethods } from "@nile-auth/core";
  *         description: Unauthorized
  *         content: {}
  */
-export async function POST(req: NextRequest) {
-  const [responder, reporter] = ResponseLogger(req, EventEnum.CREATE_USER);
+export async function createUser(
+  req: NextRequest,
+  responder: ResponderFn,
+  reporter: ReturnType<typeof ResponseLogger>[1],
+): Promise<Response> {
   try {
     const preserve = await req.clone();
     const body = await req.json();
@@ -73,6 +104,21 @@ export async function POST(req: NextRequest) {
     if (!validEmail) {
       return handleFailure(responder, undefined, "Invalid email address");
     }
+
+    // anonymous callers may create users, but never join an existing tenant
+    let tenantId = new URL(req.url).searchParams.get("tenantId");
+    if (tenantId) {
+      const [session] = await auth(req);
+      if (!session?.user?.id) {
+        return responder(null, { status: 401 });
+      }
+      if (!(await isTenantMember(sql, session.user.id, tenantId))) {
+        return responder("You are not a member of this tenant.", {
+          status: 403,
+        });
+      }
+    }
+
     const [oldUser] = await sql`
       SELECT
         *
@@ -198,9 +244,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const sps = new URL(req.url).searchParams;
-    let tenantId = sps.get("tenantId");
-    const newTenantName = sps.get("newTenantName");
+    const newTenantName = new URL(req.url).searchParams.get("newTenantName");
 
     if (newTenantName) {
       const [tenant] = await sql`
@@ -265,4 +309,9 @@ export async function POST(req: NextRequest) {
       status: 500,
     });
   }
+}
+
+export async function POST(req: NextRequest) {
+  const [responder, reporter] = ResponseLogger(req, EventEnum.CREATE_USER);
+  return createUser(req, responder, reporter);
 }

--- a/apps/server/app/v2/databases/[database]/users/route.ts
+++ b/apps/server/app/v2/databases/[database]/users/route.ts
@@ -31,9 +31,9 @@ async function isTenantMember(
       AND user_id = ${userId}
       AND tenant_id = ${tenantId}
   `;
-  if (contextError) {
-    return false;
-  }
+
+  if (contextError) return false;
+
   return Number(membership?.rows?.[0]?.count ?? 0) > 0;
 }
 
@@ -109,10 +109,10 @@ export async function createUser(
     let tenantId = new URL(req.url).searchParams.get("tenantId");
     if (tenantId) {
       const [session] = await auth(req);
-      if (!session?.user?.id) {
-        return responder(null, { status: 401 });
-      }
-      if (!(await isTenantMember(sql, session.user.id, tenantId))) {
+      if (!session?.user?.id) return responder(null, { status: 401 });
+
+      const isMember = await isTenantMember(sql, session.user.id, tenantId);
+      if (!isMember) {
         return responder("You are not a member of this tenant.", {
           status: 403,
         });


### PR DESCRIPTION
Aims to fix #143 


#### What still works

1. Creating a user with no tenant at all (this is how the SDK boots up).
2. Creating a user with a brand new tenant through `newTenantName`.
3. A signed in member creating users inside their own tenant.
4. Public sign up, including sign up with a new tenant.

Only one thing changed, that is that you can no longer target an existing tenant you were never part of.

#### Tests

Added unit tests next to the route:

1. Anonymous caller with a `tenantId` gets `401`
2. Signed in caller who is not in the target tenant gets `403`
3. Member creating into their own tenant gets `201`
4. Anonymous caller with no tenant still gets `201`